### PR TITLE
make URLs Django 1.10 compatible

### DIFF
--- a/djangojs/urls.py
+++ b/djangojs/urls.py
@@ -4,6 +4,7 @@ import sys
 from os.path import join, isdir
 
 from django.conf.urls import patterns, url
+from django.views import i18n
 
 from djangojs.conf import settings
 from djangojs.views import UrlsJsonView, ContextJsonView, JsInitView
@@ -33,5 +34,5 @@ urlpatterns = patterns('',
     url(r'^init\.js$', JsInitView.as_view(), name='django_js_init'),
     url(r'^urls$', UrlsJsonView.as_view(), name='django_js_urls'),
     url(r'^context$', ContextJsonView.as_view(), name='django_js_context'),
-    url(r'^translation$', 'django.views.i18n.javascript_catalog', js_info_dict(), name='js_catalog'),
+    url(r'^translation$', i18n.javascript_catalog, js_info_dict(), name='js_catalog'),
 )


### PR DESCRIPTION
Update urls.py to be compatible with Django 1.10. 